### PR TITLE
Feature/check existing slf

### DIFF
--- a/docs/doc_indicator_pipeline.md
+++ b/docs/doc_indicator_pipeline.md
@@ -332,6 +332,10 @@ Classe utilitaire permettant d'établir une connexion SFTP et de transférer des
     - `download_folder_recursive(remote_path: str, local_path: Path)`
         
         Télécharge récursivement tout le contenu d’un dossier distant vers un répertoire local.
+  
+    - `download_file(remote_path: str, local_path: Path)`
+    
+        Télécharge un fichier donné depuis un serveur SFTP vers un chemin local.
         
     - `upload_folder_recursive(local_path: Path, remote_path: str)`
         
@@ -366,6 +370,10 @@ Ce module contient la classe `SLFConversion`, qui centralise la logique de conve
     - `add_slf_usage()`
 
         Met à jour le fichier de suivi des *slf* convertis (`slf_usage.json`) avec tous les nouveaux ensembles de données *slf*. Cette méthode analyse le répertoire local `slf_to_compute/<année>` afin de détecter les nouveaux dossiers SLF convertis.
+    
+    - `check_patient_visits(remote_patient_path: PurePosixPath): Tuple[bool, List[str]]`
+    
+        Vérifie si toutes les visites T1 d'un patient ont déjà un fichier slf associé. Renvoie True si `all_psg_converted`, et la liste de toutes les `missing_visits`.    
 
     - `convert_folder_to_slf(local_slf_output: Path, year_dir: PurePosixPath, sftp_client: SFTPClient)`
         
@@ -472,6 +480,10 @@ Ce module contient la classe `SLFConversion`, qui centralise la logique de conve
         
         Extrait l’identifiant patient et le numéro de visite à partir d’un chemin de fichier edf. Renvoie une chaîne de caractère de la forme “PAxxxx_Vx” (ou “PAxxxx” si pas de numéro de visite).
         
+    - `extract_visits(file_list: List[str]): List[str]`
+    
+        Extrait les visites (V1, V2, etc.) des noms de fichiers PSG T1. Déduplique automatiquement même si plusieurs enregistrements existent pour la même visite/nuit.
+
     - `try_parse_number(value, as_int: bool = False): Optional[Union[int, float]]`
         
         Convertit une chaîne de caractère en *int* ou *float* et remplace les virgules par des points pour gérer les formats décimaux européens. Retourne le nombre ou None si la conversion échoue.

--- a/docs/doc_indicator_pipeline.md
+++ b/docs/doc_indicator_pipeline.md
@@ -47,7 +47,7 @@
 
 # 🔧 Stack technique
 
-- **Langage principal** : Python 3.10+
+- **Langage principal** : Python 3.10.10
 - **Structure du projet** : Organisation modulaire sous `src/` avec deux packages :
     - `indicator_pipeline` : gestion des connexions, conversions, interactions DB
     - `sleeplab_converter` : conversion des données PSG au format sleeplab

--- a/docs/doc_indicator_pipeline_english_version.md
+++ b/docs/doc_indicator_pipeline_english_version.md
@@ -527,4 +527,4 @@ It also keeps track of already processed files to avoid duplicates.
 # 📚 Resources and appendices
 
 - `README.md` – global documentation
-- `LICENSE.txt` – [**sleeplab-converter-mars](https://github.com/HP2-data/sleeplab-converter-mars)** licence
+- `LICENSE.txt` – [**sleeplab-converter-mars**](https://github.com/HP2-data/sleeplab-converter-mars) licence

--- a/docs/doc_indicator_pipeline_english_version.md
+++ b/docs/doc_indicator_pipeline_english_version.md
@@ -49,7 +49,7 @@
 
 # 🔧 Technical Stack
 
-- **Main language**: Python 3.10+
+- **Main language**: Python 3.10.10
 - **Project structure**: Modular organization under `src/` with two packages:
     - `indicator_pipeline`: handles connections, conversions, and DB interactions
     - `sleeplab_converter`: converts PSG data to the *sleeplab* format

--- a/docs/doc_indicator_pipeline_english_version.md
+++ b/docs/doc_indicator_pipeline_english_version.md
@@ -335,6 +335,10 @@ Utility class to establish an SFTP connection and transfer files or folders betw
     - `download_folder_recursive(remote_path: str, local_path: Path)`
         
         Recursively downloads the contents of a remote folder to a local directory.
+  
+    - `download_file(remote_path: str, local_path: Path)`
+    
+        Downloads a given single file from remote SFTP server to local path.
         
     - `upload_folder_recursive(local_path: Path, remote_path: str)`
         
@@ -369,6 +373,10 @@ This module contains the `SLFConversion` class, which centralizes the logic for 
     - `add_slf_usage()`
     
         Updates the *slf* usage tracking file (`slf_usage.json`) with any new SLF datasets. This method scans the local `slf_to_compute/<year>` directory to detect newly converted *slf* folders.
+
+    - `check_patient_visits(remote_patient_path: PurePosixPath): Tuple[bool, List[str]]`
+    
+        Checks whether all T1 visits for a patient already have an associated slf file. Returns True if `all_psg_converted`, and the list of `all missing_visits`.
 
     - `convert_folder_to_slf(local_slf_output: Path, year_dir: PurePosixPath, sftp_client: SFTPClient)`
         
@@ -471,6 +479,10 @@ It also keeps track of already processed files to avoid duplicates.
         
         Extracts the patient ID and visit number from an EDF file path. Returns a string in the format `"PAxxxx_Vx"` (or `"PAxxxx"` if no visit number is present).
         
+    - `extract_visits(file_list: List[str]): List[str]`
+    
+        Extracts visits (V1, V2, etc.) from PSG T1 file names. Automatically deduplicate even if multiple records exist for the same visit/night.
+
     - `try_parse_number(value, as_int: bool = False) -> Optional[Union[int, float]]`
         
         Converts a string to an *int* or *float*, replacing commas with dots to handle European decimal formats. Returns the number or `None` if conversion fails.

--- a/src/indicator_pipeline/run_pipeline.py
+++ b/src/indicator_pipeline/run_pipeline.py
@@ -80,7 +80,7 @@ def main():
             slf_converter: SLFConversion = SLFConversion(
                 local_slf_output, server_year_dir, sftp
             )
-            slf_converter.convert_folder_to_slf(year, patients)
+            slf_converter.convert_folder_to_slf(patients)
             slf_converter.upload_slf_folders_to_server()
 
         sftp.close()

--- a/src/indicator_pipeline/sftp_client.py
+++ b/src/indicator_pipeline/sftp_client.py
@@ -16,13 +16,14 @@ class SFTPClient:
     for connecting, listing files, downloading and uploading individual files or entire folders
     recursively, and closing the connection.
     """
+
     def __init__(
-        self,
-        host: str,
-        user: str = "",
-        key_path: str = "",
-        password: str = "",
-        port: int = 22,
+            self,
+            host: str,
+            user: str = "",
+            key_path: str = "",
+            password: str = "",
+            port: int = 22,
     ):
         self.host = host
         self.user = user
@@ -66,6 +67,13 @@ class SFTPClient:
             return stat.S_ISDIR(self.sftp.stat(path).st_mode)
         except IOError:
             return False
+
+    def download_file(self, remote_path: str, local_path: Path):
+        """
+        Download a single file from remote SFTP server to local path.
+        """
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        self.sftp.get(remote_path, str(local_path))
 
     def download_folder_recursive(self, remote_path: str, local_path: Path):
         """

--- a/src/indicator_pipeline/slf_conversion.py
+++ b/src/indicator_pipeline/slf_conversion.py
@@ -50,7 +50,7 @@ class SLFConversion:
 
         save_slf_usage(slf_usage)
 
-    def convert_folder_to_slf(self, year: str, patients: List[str]):
+    def convert_folder_to_slf(self, patients: List[str]):
         """
         Downloads all patient folders for a given year from a remote SFTP server in a temporary folder,
         skips those that already contain an SLF output folder,

--- a/src/indicator_pipeline/utils.py
+++ b/src/indicator_pipeline/utils.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Optional, Union, Set, Dict
+from typing import Optional, Union, Set, Dict, List
 
 
 def parse_patient_and_visit(filename: str) -> tuple[str, str]:
@@ -27,6 +27,23 @@ def extract_subject_id_from_filename(edf_file: Path) -> str:
     patient_id, visit_suffix = parse_patient_and_visit(stem)
 
     return f"PA{patient_id}_V{visit_suffix}" if visit_suffix else f"PA{patient_id}"
+
+
+def extract_visits(file_list: List[str]) -> List[str]:
+    """
+    Extract visits (V1, V2, etc.) from PSG T1 file names.
+    Automatically deduplicate even if multiple records exist for the same visit/night.
+    """
+    visits: Set = set()
+    pattern = re.compile(r"F\w+T1-PA\w+(V\d+)C\d+", re.I)
+
+    for filename in file_list:
+        if not filename.lower().endswith(".edf"):
+            continue
+        match = pattern.match(filename)
+        if match:
+            visits.add(match.group(1))
+    return sorted(visits)
 
 
 def try_parse_number(value, as_int: bool = False) -> Optional[Union[int, float]]:


### PR DESCRIPTION
- Function to extract visit number from a psg file
- Function to detect which T1 visits were not converted in slf
- Checks if each visit on the server has a slf associated
- New sftp method to download only one file from the server
- Only missing visits downloaded in tmp folder from conversion
- Only missing visits uploaded on the server
- Doc updated following changes